### PR TITLE
ci: bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ secrets.DOCKER_USER }}/godaddy-ddns
@@ -24,19 +24,19 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=alpine,enable={{is_default_branch}}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: |
             linux/amd64,linux/arm64
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Bump GitHub Actions to latest major versions:

- actions/checkout v3 -> v7
- docker/metadata-action v4 -> v6
- docker/setup-qemu-action v2 -> v4
- docker/setup-buildx-action v2 -> v4
- docker/login-action v2 -> v4
- docker/build-push-action v3 -> v7